### PR TITLE
Add example dataset for MMDet3D

### DIFF
--- a/examples/mmdet3d_dataset.py
+++ b/examples/mmdet3d_dataset.py
@@ -1,0 +1,226 @@
+"""SHIFT dataset for mmdet3d.
+
+This is a reference code for mmdet3d style dataset of the SHIFT dataset. Note that
+only single-view 3D detection and tracking are supported.
+Please refer to the torch version of the dataloader for multi-view multi-task cases.
+
+The codes are tested in mmdet3d-1.0.0.
+
+
+Example
+-------
+Below is a snippet showing how to add the SHIFTDataset class in mmdet config files.
+
+    >>> dict(
+    >>>     type='SHIFTDataset',
+    >>>     data_root='./SHIFT_dataset/discrete/images'
+    >>>     ann_file='train/front/det_3d.json',
+    >>>     img_prefix='train/front/img.zip',
+    >>>     backend_type='zip',
+    >>>     pipeline=[
+    >>>        ...
+    >>>     ]
+    >>> )
+
+
+Notes
+-----
+1.  Please copy this file to `mmdet/datasets/` and update the `mmdet/datasets/__init__.py`
+    so that the `SHIFTDataset` class is imported. You can refer to their official tutorial at
+    https://mmdetection.readthedocs.io/en/latest/tutorials/customize_dataset.html.
+2.  The `backend_type` must be one of ['file', 'zip', 'hdf5'] and the `img_prefix`
+    must be consistent with the backend_type.
+3.  Since the images are loaded before the pipeline with the selected backend, there is no need
+    to add a `LoadImageFromFileMono3D`/`LoadMultiViewImageFromFiles` module in the pipeline again.
+"""
+
+import json
+import os
+import sys
+
+import mmcv
+import numpy as np
+from mmdet3d.core.bbox import CameraInstance3DBoxes
+from mmdet3d.core.bbox.structures.box_3d_mode import Box3DMode
+from mmdet3d.datasets.builder import DATASETS
+from mmdet3d.datasets.custom_3d import Custom3DDataset
+from mmdet3d.datasets.pipelines import LoadAnnotations3D
+
+# Add the root directory of the project to the path. Remove the following two lines
+# if you have installed shift_dev as a package.
+root_dir = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
+sys.path.append(root_dir)
+
+from shift_dev.utils.backend import HDF5Backend, ZipBackend
+
+
+@DATASETS.register_module()
+class SHIFTDataset(Custom3DDataset):
+    CLASSES = ("pedestrian", "car", "truck", "bus", "motorcycle", "bicycle")
+
+    WIDTH = 1280
+    HEIGHT = 800
+
+    def __init__(self, *args, img_prefix: str = "", backend_type: str = "file", **kwargs):
+        """Initialize the SHIFT dataset.
+
+        Args:
+            backend_type (str, optional): The type of the backend. Must be one of
+                ['file', 'zip', 'hdf5']. Defaults to "file".
+        """
+        self.img_prefix = img_prefix
+        self.backend_type = backend_type
+        if backend_type == "file":
+            self.backend = None
+        elif backend_type == "zip":
+            self.backend = ZipBackend()
+        elif backend_type == "hdf5":
+            self.backend = HDF5Backend()
+        else:
+            raise ValueError(
+                f"Unknown backend type: {backend_type}! "
+                "Must be one of ['file', 'zip', 'hdf5']"
+            )
+        self.cam_intrinsic = np.array(
+            [
+                [640, 0,    self.WIDTH / 2,    0],
+                [0,   640,  self.HEIGHT / 2,   0],
+                [0,   0,    1,                 0],
+                [0,   0,    0,                 1],
+            ],
+            dtype=np.float32,
+        )
+        super().__init__(*args, **kwargs)
+
+    def load_annotations(self, ann_file):
+        print("Loading annotations...")
+        data = mmcv.load(ann_file, file_format='json')
+        data_infos = []
+        for img_idx, img_info in enumerate(data["frames"]):
+            img_filename = os.path.join(
+                self.img_prefix, img_info["videoName"], img_info["name"]
+            )
+
+            boxes = []
+            boxes_3d = []
+            labels = []
+            track_ids = []
+
+            for label in img_info["labels"]:
+                box2d = label["box2d"]
+                box3d = label["box3d"]
+                boxes.append((box2d["x1"], box2d["y1"], box2d["x2"], box2d["y2"]))
+                boxes_3d.append(
+                    box3d["location"] + box3d["dimension"] + [box3d["orientation"][1] + np.pi / 2], # yaw
+                )
+                labels.append(self.CLASSES.index(label["category"]))
+                track_ids.append(label["id"])
+
+            data_infos.append(
+                dict(
+                    sample_idx=img_idx,
+                    lidar_points=dict(lidar_path=""),   # dummy path for mmdet3d compatibility
+                    image=dict(
+                        image_idx=img_idx,
+                        image_path=img_filename,
+                        image_shape=np.array([self.HEIGHT, self.WIDTH], dtype=np.int32)
+                    ),
+                    annos=dict(
+                        num=len(boxes),
+                        boxes_2d=np.array(boxes).astype(np.float32),
+                        boxes_3d=np.array(boxes_3d).astype(np.float32),
+                        labels=np.array(labels).astype(np.int64),
+                        names=[self.CLASSES[label] for label in labels],
+                        track_ids=np.array(track_ids).astype(np.int64),
+                    ),
+                )
+            )
+        return data_infos
+
+    def get_img(self, idx):
+        filename = self.data_infos[idx]["image"]["image_path"]
+        if self.backend_type == "zip":
+            img_bytes = self.backend.get(filename)
+            return mmcv.imfrombytes(img_bytes)
+        elif self.backend_type == "hdf5":
+            img_bytes = self.backend.get(filename)
+            return mmcv.imfrombytes(img_bytes)
+        else:
+            return mmcv.imread(filename)
+
+    def get_img_info(self, idx):
+        return self.data_infos[idx]["image"]
+    
+    def get_ann_info(self, idx) -> dict:
+        annos = self.data_infos[idx]["annos"]
+        if annos["num"] != 0:
+            gt_labels = annos["labels"]
+            gt_bboxes_3d = annos["boxes_3d"]
+            gt_bboxes = annos["boxes_2d"]
+            gt_names = annos["names"]
+            gt_track_ids = annos["track_ids"]
+        else:
+            gt_labels = np.zeros((0, ), dtype=np.int64)
+            gt_bboxes_3d = np.zeros((0, 7), dtype=np.float32)
+            gt_bboxes = np.zeros((0, 4), dtype=np.float32)
+            gt_names = []
+            gt_track_ids = np.zeros((0, ), dtype=np.int64)
+
+        gt_bboxes_3d = CameraInstance3DBoxes(
+            gt_bboxes_3d, box_dim=7, with_yaw=True
+        ).convert_to(self.box_mode_3d)
+        
+        ann = dict(
+            bboxes=gt_bboxes,
+            labels=gt_labels,
+            track_ids=gt_track_ids,
+            gt_names=gt_names,
+            gt_bboxes_3d=gt_bboxes_3d,
+            gt_labels_3d=gt_labels,
+        )
+        return ann
+
+    def prepare_train_data(self, idx):
+        img = self.get_img(idx)
+        img_info = self.get_img_info(idx)
+        ann_info = self.get_ann_info(idx)
+        # Filter out images without annotations during training
+        if self.filter_empty_gt and len(ann_info["gt_bboxes_3d"]) == 0:
+            return None
+        results = dict(img=img, img_info=img_info, cam2img=self.cam_intrinsic, ann_info=ann_info)
+        self.pre_pipeline(results)
+        return self.pipeline(results)
+
+    def prepare_test_data(self, idx):
+        img = self.get_img(idx)
+        img_info = self.get_img_info(idx)
+        results = dict(img=img, img_info=img_info, cam2img=self.cam_intrinsic)
+        self.pre_pipeline(results)
+        return self.pipeline(results)
+
+
+if __name__ == "__main__":
+    """Example for loading the SHIFT dataset for monocular 3D detection."""
+
+    dataset = SHIFTDataset(
+        data_root="./data/discrete/images",
+        ann_file="./data/discrete/images/val/front/det_3d.json",
+        img_prefix="./data/discrete/images/val/front/img.zip",
+        box_type_3d="Camera",
+        backend_type="zip",
+        pipeline=[LoadAnnotations3D(with_bbox=True)],
+    )
+
+    # Print the dataset size
+    print(f"Total number of samples: {len(dataset)}.")
+
+    # Print the tensor shape of the first batch.
+    for i, data in enumerate(dataset):
+        print(f"Sample {i}:")
+        print("img:", data["img"].shape)
+        print("annos.gt_bboxes_3d:", data["ann_info"]["gt_bboxes_3d"])
+        print("annos.gt_labels_3d:", data["ann_info"]["gt_labels_3d"])
+        print("annos.gt_bboxes:", data["ann_info"]["bboxes"])
+        print("annos.gt_labels:", data["ann_info"]["labels"])
+        print("annos.track_ids:", data["ann_info"]["track_ids"])
+        break

--- a/examples/mmdet3d_dataset.py
+++ b/examples/mmdet3d_dataset.py
@@ -58,7 +58,7 @@ class SHIFTDataset(Custom3DDataset):
 
     WIDTH = 1280
     HEIGHT = 800
-    MAX_DEPTH = 1000.0
+    DEPTH_FACTOR = 16777.216  #  256 ** 3 / 1000.0
 
     def __init__(
         self, 
@@ -198,7 +198,7 @@ class SHIFTDataset(Custom3DDataset):
         depth_img = self.read_image(depth_filename)
         depth_img = depth_img.astype(np.float32)
         depth = depth_img[:, :, 0] * 256 * 256 + depth_img[:, :, 1] * 256 + depth_img[:, :, 2]
-        depth = depth / MAX_DEPTH
+        depth = depth * DEPTH_FACTOR
         return depth
 
     def get_img_info(self, idx):

--- a/examples/mmdet3d_dataset.py
+++ b/examples/mmdet3d_dataset.py
@@ -1,7 +1,7 @@
 """SHIFT dataset for mmdet3d.
 
 This is a reference code for mmdet3d style dataset of the SHIFT dataset. Note that
-only single-view 3D detection and tracking are supported.
+only monocular 3D detection and tracking are supported.
 Please refer to the torch version of the dataloader for multi-view multi-task cases.
 
 The codes are tested in mmdet3d-1.0.0.
@@ -14,8 +14,8 @@ Below is a snippet showing how to add the SHIFTDataset class in mmdet config fil
     >>> dict(
     >>>     type='SHIFTDataset',
     >>>     data_root='./SHIFT_dataset/discrete/images'
-    >>>     ann_file='train/front/det_3d.json',
-    >>>     img_prefix='train/front/img.zip',
+    >>>     ann_file='./SHIFT_dataset/discrete/images/train/front/det_3d.json',
+    >>>     img_prefix='./SHIFT_dataset/discrete/images/train/front/img.zip',
     >>>     backend_type='zip',
     >>>     pipeline=[
     >>>        ...
@@ -203,9 +203,9 @@ if __name__ == "__main__":
     """Example for loading the SHIFT dataset for monocular 3D detection."""
 
     dataset = SHIFTDataset(
-        data_root="./data/discrete/images",
-        ann_file="./data/discrete/images/val/front/det_3d.json",
-        img_prefix="./data/discrete/images/val/front/img.zip",
+        data_root="./SHIFT_dataset/discrete/images",
+        ann_file="./SHIFT_dataset/discrete/images/val/front/det_3d.json",
+        img_prefix="./SHIFT_dataset/discrete/images/val/front/img.zip",
         box_type_3d="Camera",
         backend_type="zip",
         pipeline=[LoadAnnotations3D(with_bbox=True)],

--- a/examples/mmdet3d_dataset.py
+++ b/examples/mmdet3d_dataset.py
@@ -249,9 +249,10 @@ class SHIFTDataset(Custom3DDataset):
         # Add lidar2cam matrix for compatibility (e.g., PETR)
         results["lidar2cam"] = np.eye(4)
         # Set initial shape for mmdet3d pipeline compatibility
-        results["img_shape"] = img[0].shape
-        results["ori_shape"] = img[0].shape
-        results["pad_shape"] = img[0].shape
+        img_shape = img[0][..., np.newaxis].shape
+        results["img_shape"] = img_shape
+        results["ori_shape"] = img_shape
+        results["pad_shape"] = img_shape
         self.pre_pipeline(results)
         return self.pipeline(results)
 
@@ -260,9 +261,10 @@ class SHIFTDataset(Custom3DDataset):
         img_info = self.get_img_info(idx)
         results = dict(img=img, img_info=img_info, cam2img=self.cam_intrinsic)
         results["lidar2cam"] = np.eye(4)
-        results["img_shape"] = img[0].shape
-        results["ori_shape"] = img[0].shape
-        results["pad_shape"] = img[0].shape
+        img_shape = img[0][..., np.newaxis].shape
+        results["img_shape"] = img_shape
+        results["ori_shape"] = img_shape
+        results["pad_shape"] = img_shape
         self.pre_pipeline(results)
         return self.pipeline(results)
 

--- a/examples/mmdet3d_dataset.py
+++ b/examples/mmdet3d_dataset.py
@@ -240,6 +240,8 @@ class SHIFTDataset(Custom3DDataset):
         results = dict(img=img, img_info=img_info, cam2img=self.cam_intrinsic, ann_info=ann_info)
         if self.depth_prefix != "":
             results["gt_depth"] = self.get_depth(idx)
+        # Add lidar2cam matrix for compatibility (e.g., PETR)
+        results["lidar2cam"] = np.eye(4)
         self.pre_pipeline(results)
         return self.pipeline(results)
 
@@ -247,6 +249,7 @@ class SHIFTDataset(Custom3DDataset):
         img = self.get_img(idx)
         img_info = self.get_img_info(idx)
         results = dict(img=img, img_info=img_info, cam2img=self.cam_intrinsic)
+        results["lidar2cam"] = np.eye(4)
         self.pre_pipeline(results)
         return self.pipeline(results)
 

--- a/examples/mmdet_dataset.py
+++ b/examples/mmdet_dataset.py
@@ -42,8 +42,9 @@ import sys
 
 import mmcv
 import numpy as np
-from mmdet3d.datasets.builder import DATASETS
-from mmdet3d.datasets.custom import CustomDataset
+from mmdet.datasets.builder import DATASETS
+from mmdet.datasets.custom import CustomDataset
+from mmdet.datasets.pipelines import LoadAnnotations
 
 # Add the root directory of the project to the path. Remove the following two lines
 # if you have installed shift_dev as a package.

--- a/examples/mmdet_dataset.py
+++ b/examples/mmdet_dataset.py
@@ -83,6 +83,7 @@ class SHIFTDataset(CustomDataset):
             )
 
     def load_annotations(self, ann_file):
+        print("Loading annotations...")
         with open(ann_file, "r") as f:
             data = json.load(f)
 

--- a/examples/mmdet_dataset.py
+++ b/examples/mmdet_dataset.py
@@ -42,9 +42,8 @@ import sys
 
 import mmcv
 import numpy as np
-from mmdet.datasets.builder import DATASETS
-from mmdet.datasets.custom import CustomDataset
-from mmdet.datasets.pipelines import LoadAnnotations
+from mmdet3d.datasets.builder import DATASETS
+from mmdet3d.datasets.custom import CustomDataset
 
 # Add the root directory of the project to the path. Remove the following two lines
 # if you have installed shift_dev as a package.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ PyYAML==6.0
 scalabel==0.3.0
 scikit_image==0.18.3
 tqdm==4.38.0
+torch==1.13.1
 git+https://github.com/scalabel/scalabel.git

--- a/shift_dev/io/decompress_videos.py
+++ b/shift_dev/io/decompress_videos.py
@@ -5,7 +5,6 @@ import glob
 import multiprocessing as mp
 import os
 import shutil
-from asyncore import write
 from functools import partial
 
 import cv2


### PR DESCRIPTION
Add an example dataset API for mmdet3d (v1.0+). It supports monocular tasks, including 2D/3D detection, tracking, 2D instance segmentation, and depth estimation.

Usage:
```python
dict(
    type='SHIFTDataset',
    data_root='./SHIFT_dataset/discrete/images',
    img_prefix='train/front/img.zip',
    ann_file='train/front/det_3d.json',
    insseg_ann_file="train/front/det_insseg_2d.json",
    backend_type='zip',
    pipeline=[
        dict(type="LoadAnnotations3D", with_bbox=True, with_mask=True),
        ...
    ]
)
```