### PR TITLE
limit python version to <=3.9 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.7, <=3.9",
     install_requires=[
         "h5py",
         "matplotlib",


### PR DESCRIPTION
I tried different versions and wondered why it didn't work.
Turns out, that python <=3.9 is required